### PR TITLE
Tool pre check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ RESET=$(shell tput sgr0)
 
 # Check for necessary tools
 ifeq (, $(shell which aws))
-    $(error "No aws in $(PATH), go to https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html, pick your OS, and follow the instructions")
+	$(error "No aws in $(PATH), go to https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html, pick your OS, and follow the instructions")
 endif
 ifeq (, $(shell which jq))
-    $(error "No jq in $(PATH), please install jq")
+	$(error "No jq in $(PATH), please install jq")
 endif
 ifeq (, $(shell which terraform))
-    $(error "No terraform in $(PATH), get it from https://www.terraform.io/downloads.html")
+	$(error "No terraform in $(PATH), get it from https://www.terraform.io/downloads.html")
 endif
 
 help:
@@ -132,14 +132,20 @@ plan: prep ## Show what terraform thinks it will do
 format: prep ## Rewrites all Terraform configuration files to a canonical format.
 	@terraform fmt \
 		-write=true \
-    -recursive
+		-recursive
 
 # https://github.com/terraform-linters/tflint
 lint: prep ## Check for possible errors, best practices, etc in current directory!
+	ifeq (, $(shell which tflint))
+		$(error "No tflint in $(PATH), get it from https://github.com/terraform-linters/tflint")
+	endif
 	@tflint
 
 # https://github.com/liamg/tfsec
 check-security: prep ## Static analysis of your terraform templates to spot potential security issues.
+	ifeq (, $(shell which tfsec))
+		$(error "No tfsec in $(PATH), get it from https://github.com/liamg/tfsec")
+	endif
 	@tfsec .
 
 documentation: prep ## Generate README.md for a module

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,17 @@ GREEN=$(shell tput setaf 2)
 YELLOW=$(shell tput setaf 3)
 RESET=$(shell tput sgr0)
 
+# Check for necessary tools
+ifeq (, $(shell which aws))
+    $(error "No aws in $(PATH), go to https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html, pick your OS, and follow the instructions")
+endif
+ifeq (, $(shell which jq))
+    $(error "No jq in $(PATH), please install jq")
+endif
+ifeq (, $(shell which terraform))
+    $(error "No terraform in $(PATH), get it from https://www.terraform.io/downloads.html")
+endif
+
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 

--- a/Makefile
+++ b/Makefile
@@ -136,16 +136,10 @@ format: prep ## Rewrites all Terraform configuration files to a canonical format
 
 # https://github.com/terraform-linters/tflint
 lint: prep ## Check for possible errors, best practices, etc in current directory!
-	ifeq (, $(shell which tflint))
-		$(error "No tflint in $(PATH), get it from https://github.com/terraform-linters/tflint")
-	endif
 	@tflint
 
 # https://github.com/liamg/tfsec
 check-security: prep ## Static analysis of your terraform templates to spot potential security issues.
-	ifeq (, $(shell which tfsec))
-		$(error "No tfsec in $(PATH), get it from https://github.com/liamg/tfsec")
-	endif
 	@tfsec .
 
 documentation: prep ## Generate README.md for a module


### PR DESCRIPTION
Add checks to the beginning of the script to check that required tools exist. Otherwise the make file will fail in the middle of execution which is not ideal.

Also fix the tabbing on `-recursive` to align it with the rest of the command.